### PR TITLE
Initialization, removing Werkzeug

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,4 +26,4 @@ urllib3
 whitenoise
 django-analytical
 django-extensions 
-Werkzeug==2.0.3
+# Werkzeug==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,14 @@ urllib3==1.26.15
     # via
     #   -r requirements.in
     #   requests
-werkzeug==2.2.3
+# 
+# Uninstalling werkzeug experimentation on 8 May 2023
+#
+# werkzeug==2.2.3
+#
+#
+#
+
     # via -r requirements.in
 whitenoise==6.4.0
     # via


### PR DESCRIPTION
I uninstalled the problem package using pip: `werkzeug`  and removed it from `requirements.in` and `requirements.txt`.

The above changes caused my Django development serve to show these errors:
```
[08/May/2023 22:35:21] code 400, message Bad request version ('localhost\x00')
[08/May/2023 22:35:21] You're accessing the development server over HTTPS, but it only supports HTTP.
[08/May/2023 22:35:21] code 400, message Bad request version ('\x02h2\x08http/1.1\x00-\x00\x02\x01\x01\x00')
[08/May/2023 22:35:21] code 400, message Bad request version ('zeú\x16')
[08/May/2023 22:35:21] You're accessing the development server over HTTPS, but it only supports HTTP.
[08/May/2023 22:35:21] You're accessing the development server over HTTPS, but it only supports HTTP.
[08/May/2023 22:35:21] code 400, message Bad request version ('\x02§Ü\x00')
[08/May/2023 22:35:21] You're accessing the development server over HTTPS, but it only supports HTTP.
```

So I turned to ChatGPT and suggested I try using `ngrok`:

![Screenshot from 2023-05-08 18-40-43](https://user-images.githubusercontent.com/6686723/236954020-75e3d769-5afa-46e4-afdd-7757c8ed216a.png)

