### PR TITLE
Changes to accomodate gateway-defender 0.1.4

### DIFF
--- a/tarot_juicer/settings.py
+++ b/tarot_juicer/settings.py
@@ -76,6 +76,7 @@ INSTALLED_APPS = [
     "widget_tweaks",
     "gateway_defender",
     "cookie_consent",
+    "django.contrib.sites",
 ]
 
 MIDDLEWARE = [
@@ -91,6 +92,7 @@ MIDDLEWARE = [
     # 'tarot_juicer.middlewares.authentication_middleware',
     # 'tarot_juicer.middlewares.autologout_middleware',
     # 'tarot_juicer.protected_path_middleware.path_protection_middleware',  
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
 ]
 
 ROOT_URLCONF = 'tarot_juicer.urls'
@@ -115,6 +117,9 @@ TEMPLATES = [
         },
     },
 ]
+
+# Info for gateway-defender to know which template to render when user is authenticated
+GATEWAY_PORTAL_TEMPLATE = "landings/portal.html"
 
 WSGI_APPLICATION = 'tarot_juicer.wsgi.application'
 


### PR DESCRIPTION
- Added the `'django.contrib.sites'` to the INSTALLED_APPS = [].
- Added the `'django.contrib.sites.middleware.CurrentSiteMiddleware'`,in the MIDDLEWARE = [], so that the sites can recognize the domain of the current site.
- Added `GATEWAY_PORTAL_TEMPLATE = ` to settings.py, so that gateway-defender knows which html template to render when the user is authenticated.